### PR TITLE
fix: deactivate token authentication

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ fuse:
   environment:
     # enable services interface in managment frontend
     FUSE_OPTS: docsearch
+    FUSE_AUTH: none
 fileserver:
   image: nginx:1.9.11
   volumes:


### PR DESCRIPTION
Needed so docsearch works with new Fuse version
